### PR TITLE
Switch to ruby/setup-ruby

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
 

--- a/sequel-snowflake.gemspec
+++ b/sequel-snowflake.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Sequel::Snowflake::VERSION
   spec.authors       = ["Yesware, Inc"]
   spec.email         = ["engineering@yesware.com"]
-  spec.license       = ["MIT"]
+  spec.license       = "MIT"
   spec.summary       = %q{Sequel adapter for Snowflake}
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/Yesware/sequel-snowflake"

--- a/sequel-snowflake.gemspec
+++ b/sequel-snowflake.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Sequel::Snowflake::VERSION
   spec.authors       = ["Yesware, Inc"]
   spec.email         = ["engineering@yesware.com"]
+  spec.license       = ["MIT"]
   spec.summary       = %q{Sequel adapter for Snowflake}
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/Yesware/sequel-snowflake"


### PR DESCRIPTION
When building the latest release, the Workflow noted that `actions/setup-ruby` is deprecated, and we should instead use `ruby/setup-ruby`.

Also add "MIT" as the license in the gemspec. The library is already licensed as MIT (see LICENSE), but this change would update the "license" entry on the RubyGems site.

Specs will still be run for this, and the RubyGem release workflow will still attempt to run after this is merged, but will fail because it's still v2.0.0. This won't need a version bump because this is not a change to the library code, so the built gem would remain unchanged. The RubyGems license change can come along with the next significant update.