### PR TITLE
The syntax between actions/setup-ruby and ruby/setup-ruby are different

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
 
     - name: Publish to RubyGems
       run: |


### PR DESCRIPTION
The syntax is now "2.6" instead of "2.6.x", this prevents the workflow from executing successfully.