### PR TITLE
Add `explain` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
-### 2.0.0 / 2021-06-16
+# Changelog
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## 2.1.0 / 2022-06-17
+* Add support for `EXPLAIN`.
+
+## 2.0.0 / 2021-06-16
 * Change LICENSE to MIT (open source).
 * This gem is now tested against Rubies 2.6, 2.7, and 3.0.
 
-
-### 1.0.0 / 2021-04-22 [Initial Release]
-
+## 1.0.0 / 2021-04-22 [Initial Release]
 * Handle parsing Snowflake values for the following types:
     * Numeric data types
     * String data types

--- a/lib/sequel-snowflake/version.rb
+++ b/lib/sequel-snowflake/version.rb
@@ -1,6 +1,6 @@
 module Sequel
   module Snowflake
     # sequel-snowflake version
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end

--- a/lib/sequel/adapters/shared/snowflake.rb
+++ b/lib/sequel/adapters/shared/snowflake.rb
@@ -1,0 +1,32 @@
+module Sequel
+  module Snowflake
+    Sequel::Database.set_shared_adapter_scheme(:snowflake, self)
+
+    module DatasetMethods
+      # Return an array of strings specifying a query explanation for a SELECT of the
+      # current dataset.
+      # The options (symbolized, in lowercase) are:
+      #   JSON: JSON output is easier to store in a table and query.
+      #   TABULAR (default): tabular output is generally more human-readable than JSON output.
+      #   TEXT: formatted text output is generally more human-readable than JSON output.
+      def explain(opts=OPTS)
+        # Load the PrettyTable class, needed for explain output
+        Sequel.extension(:_pretty_table) unless defined?(Sequel::PrettyTable)
+
+        if opts[:tabular]
+          explain_with_format = "EXPLAIN USING TABULAR"
+        elsif opts[:json]
+          explain_with_format = "EXPLAIN USING JSON"
+        elsif opts[:text]
+          explain_with_format = "EXPLAIN USING TEXT"
+        else
+          explain_with_format = "EXPLAIN"
+        end
+
+        ds = db.send(:metadata_dataset).clone(:sql=>"#{explain_with_format} #{select_sql}")
+        rows = ds.all
+        Sequel::PrettyTable.string(rows, ds.columns)
+      end
+    end
+  end
+end

--- a/lib/sequel/adapters/shared/snowflake.rb
+++ b/lib/sequel/adapters/shared/snowflake.rb
@@ -13,14 +13,14 @@ module Sequel
         # Load the PrettyTable class, needed for explain output
         Sequel.extension(:_pretty_table) unless defined?(Sequel::PrettyTable)
 
-        if opts[:tabular]
-          explain_with_format = "EXPLAIN USING TABULAR"
+        explain_with_format = if opts[:tabular]
+          "EXPLAIN USING TABULAR"
         elsif opts[:json]
-          explain_with_format = "EXPLAIN USING JSON"
+          "EXPLAIN USING JSON"
         elsif opts[:text]
-          explain_with_format = "EXPLAIN USING TEXT"
+          "EXPLAIN USING TEXT"
         else
-          explain_with_format = "EXPLAIN"
+          "EXPLAIN"
         end
 
         ds = db.send(:metadata_dataset).clone(:sql=>"#{explain_with_format} #{select_sql}")

--- a/lib/sequel/adapters/snowflake.rb
+++ b/lib/sequel/adapters/snowflake.rb
@@ -1,5 +1,6 @@
 require 'sequel'
 require 'sequel/adapters/odbc'
+require_relative 'shared/snowflake'
 
 # A lightweight adapter providing Snowflake support for the `sequel` gem.
 # The only difference between this and the Sequel-provided ODBC adapter is
@@ -20,6 +21,8 @@ module Sequel
 
     # A custom Sequel Dataset class crafted specifically to handle Snowflake results.
     class Dataset < Sequel::ODBC::Dataset
+      include Sequel::Snowflake::DatasetMethods
+
       def fetch_rows(sql)
         execute(sql) do |s|
           i = -1


### PR DESCRIPTION
Add the ability to run `#explain` on a Dataset. This supports all the output formats that Snowflake offers when using EXPLAIN:

> * JSON: JSON output is easier to store in a table and query.
> * TABULAR: tabular output is generally more human-readable than JSON output.
> * TEXT: formatted text output is generally more human-readable than JSON output.
>
> The default is TABULAR.
