### PR TITLE
Drop testing for Ruby 2.7; update the Snowflake ODBC driver

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ruby 2.7 was EOL'ed just last week. I attempted to add Ruby 3.2 support, but the ruby-odbc gem doesn't work for Ruby 3.2 (build issues), and is not actively maintained; there's an unofficial fork that works, but since it isn't published on RubyGems I can't point to that version in the gemspec.

Also updating the Snowflake ODBC driver link to ensure we're on the latest here as well.