### PR TITLE
Add additional unixODBC setup details to README

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 3.1
+    - name: Set up Ruby 3.3
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3.3
 
     - name: Publish to RubyGems
       run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Snowflake ODBC driver
       run: curl ${SNOWFLAKE_DRIVER_URL} -o snowflake_driver.deb && sudo dpkg -i snowflake_driver.deb
       env:
-        SNOWFLAKE_DRIVER_URL: https://sfc-repo.snowflakecomputing.com/odbc/linuxaarch64/3.4.1/snowflake-odbc-3.4.1.aarch64.deb
+        SNOWFLAKE_DRIVER_URL: https://sfc-repo.snowflakecomputing.com/odbc/linux/3.4.1/snowflake-odbc-3.4.1.x86_64.deb
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1']
+        ruby-version: ['3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
     - name: Install Snowflake ODBC driver
       run: curl ${SNOWFLAKE_DRIVER_URL} -o snowflake_driver.deb && sudo dpkg -i snowflake_driver.deb
       env:
-        SNOWFLAKE_DRIVER_URL: https://sfc-repo.snowflakecomputing.com/odbc/linux/3.1.1/snowflake-odbc-3.1.1.x86_64.deb
+        SNOWFLAKE_DRIVER_URL: https://sfc-repo.snowflakecomputing.com/odbc/linux/3.3.2/snowflake_linux_x8664_odbc-3.3.2.tgz
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Snowflake ODBC driver
       run: curl ${SNOWFLAKE_DRIVER_URL} -o snowflake_driver.deb && sudo dpkg -i snowflake_driver.deb
       env:
-        SNOWFLAKE_DRIVER_URL: https://sfc-repo.snowflakecomputing.com/odbc/linux/3.3.2/snowflake_linux_x8664_odbc-3.3.2.tgz
+        SNOWFLAKE_DRIVER_URL: https://sfc-repo.snowflakecomputing.com/odbc/linuxaarch64/3.4.1/snowflake-odbc-3.4.1.aarch64.deb
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ You'll also need [unixODBC](http://www.unixodbc.org/) (if on Linux/macOS) and th
 this adapter. Follow the Snowflake documentation on their ODBC Driver
 [here](https://docs.snowflake.com/en/user-guide/odbc.html) before proceeding.
 
+After installing, you may need to configure `simba.snowflake.ini` and set
+`DriverManagerEncoding` to "UTF-16", the default encoding for unixODBC. If
+unixODBC was built specifically with the `DSQL_WCHART_CONVERT` flag, then
+Snowflake's default of "UTF-32" is fine as-is.
+
 ## Usage
 
 When establishing the connection, specify `:snowflake` as the adapter to use.


### PR DESCRIPTION
Adds additional detail for setup step to help avoid the situation found in #16 .

Also bumped the workflows to test against the latest Snowflake driver + newer Ruby versions. This won't be a version bump as functionally nothing has changed.