### PR TITLE
Add support for GROUP BY (CUBE, ROLLUP, SETS)

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 3.3
+    - name: Set up Ruby 3.4
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: 3.4
 
     - name: Publish to RubyGems
       run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3']
+        ruby-version: ['3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
     - name: Install Snowflake ODBC driver
       run: curl ${SNOWFLAKE_DRIVER_URL} -o snowflake_driver.deb && sudo dpkg -i snowflake_driver.deb
       env:
-        SNOWFLAKE_DRIVER_URL: https://sfc-repo.snowflakecomputing.com/odbc/linux/3.4.1/snowflake-odbc-3.4.1.x86_64.deb
+        SNOWFLAKE_DRIVER_URL: https://sfc-repo.snowflakecomputing.com/odbc/linux/3.12.0/snowflake-odbc-3.12.0.x86_64.deb
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Add support for `GROUP CUBE`
 * Add support for `GROUP ROLLUP`
 * Add support for `GROUPING SETS`
-* Add support for `JOIN LATERAL`
 
 ## 2.2.0 / 2023-10-17
 * Add support for `MERGE` (credit: @benalavi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.3.0 / 2025-01-31
+* Add support for `GROUP CUBE`
+* Add support for `GROUP ROLLUP`
+* Add support for `GROUPING SETS`
+* Add support for `JOIN LATERAL`
+
 ## 2.2.0 / 2023-10-17
 * Add support for `MERGE` (credit: @benalavi)
 * Add requirement for `sequel` v5.58.0 or newer (to support the new MERGE methods).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.3.0 / 2025-01-31
+## 2.3.0 / 2025-11-17
 * Add support for `GROUP CUBE`
 * Add support for `GROUP ROLLUP`
 * Add support for `GROUPING SETS`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ be taken down either via the `after(:each)` blocks or when the connection is clo
 
 We have two workflows included in this project:
 
-* Ruby (`ruby.yml`): This runs the specs for this gem against Ruby 3.0 and 3.1. Note
+* Ruby (`ruby.yml`): This runs the specs for this gem against Ruby 3.3 and 3.4. Note
 that this requires the secret `SNOWFLAKE_CONN_STR` to be set (see above for example connection string),
 as we need to connect to Snowflake to run tests. These specs will be run for every pull request,
 and is run after every commit to those branches.

--- a/lib/sequel-snowflake/version.rb
+++ b/lib/sequel-snowflake/version.rb
@@ -1,6 +1,6 @@
 module Sequel
   module Snowflake
     # sequel-snowflake version
-    VERSION = "2.2.0"
+    VERSION = "2.3.0"
   end
 end

--- a/lib/sequel/adapters/snowflake.rb
+++ b/lib/sequel/adapters/snowflake.rb
@@ -53,11 +53,6 @@ module Sequel
         true
       end
 
-      # https://docs.snowflake.com/en/sql-reference/constructs/join-lateral
-      def supports_lateral_subqueries?
-        true
-      end
-
       # https://docs.snowflake.com/en/sql-reference/sql/merge
       def supports_merge?
         true

--- a/lib/sequel/adapters/snowflake.rb
+++ b/lib/sequel/adapters/snowflake.rb
@@ -38,9 +38,27 @@ module Sequel
         self
       end
 
-      # Whether the MERGE statement is supported:
-      # https://github.com/jeremyevans/sequel/blob/master/lib/sequel/dataset/features.rb#L129
-      # Snowflake reference: https://docs.snowflake.com/en/sql-reference/sql/merge
+      # https://docs.snowflake.com/en/sql-reference/constructs/group-by-cube
+      def supports_group_cube?
+        true
+      end
+
+      # https://docs.snowflake.com/en/sql-reference/constructs/group-by-rollup
+      def supports_group_rollup?
+        true
+      end
+
+      # https://docs.snowflake.com/en/sql-reference/constructs/group-by-grouping-sets
+      def supports_grouping_sets?
+        true
+      end
+
+      # https://docs.snowflake.com/en/sql-reference/constructs/join-lateral
+      def supports_lateral_subqueries?
+        true
+      end
+
+      # https://docs.snowflake.com/en/sql-reference/sql/merge
       def supports_merge?
         true
       end

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+ruby = "latest"

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -1,7 +1,15 @@
 require 'securerandom'
 
 describe Sequel::Snowflake::Dataset do
-  let(:db) { Sequel.connect(adapter: :snowflake, drvconnect: ENV['SNOWFLAKE_CONN_STR']) }
+  let(:db) { @db ||= Sequel.connect(adapter: :snowflake, drvconnect: ENV['SNOWFLAKE_CONN_STR']) }
+  
+  before(:all) do
+    @db = Sequel.connect(adapter: :snowflake, drvconnect: ENV['SNOWFLAKE_CONN_STR'])
+  end
+  
+  after(:all) do
+    @db.disconnect if @db
+  end
 
   describe 'Converting Snowflake data types' do
     # Create a test table with a reasonably-random suffix
@@ -70,17 +78,17 @@ describe Sequel::Snowflake::Dataset do
     end
   end
 
-  describe 'GROUP CUBE feature' do
-    let(:products) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
-    let(:sales) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
+  describe 'GROUP BY features' do
+    before(:all) do
+      @products = "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym
+      @sales = "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym
 
-    before(:each) do
-      db.create_table(products, :temp => true) do
+      @db.create_table(@products, :temp => true) do
         Integer :product_id
         Float :wholesale_price
       end
 
-      db.create_table(sales, :temp => true) do
+      @db.create_table(@sales, :temp => true) do
         Integer :product_id
         Float :retail_price
         Integer :quantity
@@ -88,21 +96,24 @@ describe Sequel::Snowflake::Dataset do
         String :state
       end
 
-      db[products].insert({ product_id: 1, wholesale_price: 1.00 })
-      db[products].insert({ product_id: 2, wholesale_price: 2.00 })
-      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 1, city: 'SF', state: 'CA' })
-      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 2, city: 'SJ', state: 'CA' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 4, city: 'SF', state: 'CA' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 8, city: 'SJ', state: 'CA' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 16, city: 'Miami', state: 'FL' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 32, city: 'Orlando', state: 'FL' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 64, city: 'SJ', state: 'CA' })
+      @db[@products].insert({ product_id: 1, wholesale_price: 1.00 })
+      @db[@products].insert({ product_id: 2, wholesale_price: 2.00 })
+      @db[@sales].insert({ product_id: 1, retail_price: 2.00, quantity: 1, city: 'SF', state: 'CA' })
+      @db[@sales].insert({ product_id: 1, retail_price: 2.00, quantity: 2, city: 'SJ', state: 'CA' })
+      @db[@sales].insert({ product_id: 2, retail_price: 5.00, quantity: 4, city: 'SF', state: 'CA' })
+      @db[@sales].insert({ product_id: 2, retail_price: 5.00, quantity: 8, city: 'SJ', state: 'CA' })
+      @db[@sales].insert({ product_id: 2, retail_price: 5.00, quantity: 16, city: 'Miami', state: 'FL' })
+      @db[@sales].insert({ product_id: 2, retail_price: 5.00, quantity: 32, city: 'Orlando', state: 'FL' })
+      @db[@sales].insert({ product_id: 2, retail_price: 5.00, quantity: 64, city: 'SJ', state: 'CA' })
     end
 
-    after(:each) do
-      db.drop_table(products)
-      db.drop_table(sales)
+    after(:all) do
+      @db.drop_table(@products) if @products
+      @db.drop_table(@sales) if @sales
     end
+
+    let(:products) { @products }
+    let(:sales) { @sales }
 
     it 'can use GROUP CUBE' do
       res = db.from(Sequel[products].as(:p)).
@@ -132,41 +143,6 @@ describe Sequel::Snowflake::Dataset do
         { state: nil, city: nil, profit: 375 },
       ])
     end
-  end
-
-  describe 'GROUP ROLLUP feature' do
-    let(:products) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
-    let(:sales) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
-
-    before(:each) do
-      db.create_table(products, :temp => true) do
-        Integer :product_id
-        Float :wholesale_price
-      end
-
-      db.create_table(sales, :temp => true) do
-        Integer :product_id
-        Float :retail_price
-        Integer :quantity
-        String :city
-        String :state
-      end
-
-      db[products].insert({ product_id: 1, wholesale_price: 1.00 })
-      db[products].insert({ product_id: 2, wholesale_price: 2.00 })
-      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 1, city: 'SF', state: 'CA' })
-      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 2, city: 'SJ', state: 'CA' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 4, city: 'SF', state: 'CA' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 8, city: 'SJ', state: 'CA' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 16, city: 'Miami', state: 'FL' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 32, city: 'Orlando', state: 'FL' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 64, city: 'SJ', state: 'CA' })
-    end
-
-    after(:each) do
-      db.drop_table(products)
-      db.drop_table(sales)
-    end
 
     it 'can use GROUP ROLLUP' do
       res = db.from(Sequel[products].as(:p)).
@@ -191,41 +167,6 @@ describe Sequel::Snowflake::Dataset do
         { state: 'FL', city: nil, profit: 144 },
         { state: nil, city: nil, profit: 375 },
       ])
-    end
-  end
-
-  describe 'GROUPING SETS feature' do
-    let(:products) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
-    let(:sales) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
-
-    before(:each) do
-      db.create_table(products, :temp => true) do
-        Integer :product_id
-        Float :wholesale_price
-      end
-
-      db.create_table(sales, :temp => true) do
-        Integer :product_id
-        Float :retail_price
-        Integer :quantity
-        String :city
-        String :state
-      end
-
-      db[products].insert({ product_id: 1, wholesale_price: 1.00 })
-      db[products].insert({ product_id: 2, wholesale_price: 2.00 })
-      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 1, city: 'SF', state: 'CA' })
-      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 2, city: 'SJ', state: 'CA' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 4, city: 'SF', state: 'CA' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 8, city: 'SJ', state: 'CA' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 16, city: 'Miami', state: 'FL' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 32, city: 'Orlando', state: 'FL' })
-      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 64, city: 'SJ', state: 'CA' })
-    end
-
-    after(:each) do
-      db.drop_table(products)
-      db.drop_table(sales)
     end
 
     it 'can use GROUPING SETS' do
@@ -253,89 +194,40 @@ describe Sequel::Snowflake::Dataset do
     end
   end
 
-  describe 'LATERAL JOIN feature' do
-    let(:employees) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
-    let(:departments) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
-
-    before(:each) do
-      db.create_table(departments, :temp => true) do
-        Integer :dept_id
-        String :dept_name
-        Integer :budget
-      end
-
-      db.create_table(employees, :temp => true) do
-        Integer :emp_id
-        String :emp_name
-        Integer :dept_id
-        Integer :salary
-      end
-
-      db[departments].insert({ dept_id: 1, dept_name: 'Engineering', budget: 100000 })
-      db[departments].insert({ dept_id: 2, dept_name: 'Sales', budget: 80000 })
-      db[employees].insert({ emp_id: 1, emp_name: 'Alice', dept_id: 1, salary: 75000 })
-      db[employees].insert({ emp_id: 2, emp_name: 'Bob', dept_id: 1, salary: 80000 })
-      db[employees].insert({ emp_id: 3, emp_name: 'Charlie', dept_id: 2, salary: 60000 })
-      db[employees].insert({ emp_id: 4, emp_name: 'Diana', dept_id: 2, salary: 65000 })
-    end
-
-    after(:each) do
-      db.drop_table(employees)
-      db.drop_table(departments)
-    end
-
-    it 'can use LATERAL JOIN' do
-      res = db.from(
-        Sequel[departments].as(:d),
-        db[employees].
-          where(Sequel[:d][:dept_id] => :dept_id).
-          select(:emp_name, :salary).
-          lateral.
-          as(:e)
-      ).
-        select(
-          Sequel[:d][:dept_name],
-          Sequel[:e][:emp_name].as(:employee),
-          Sequel[:e][:salary]
-        ).
-        order(Sequel[:d][:dept_name], Sequel.desc(Sequel[:e][:salary])).
-        all
-
-      expect(res).to match_array([
-        { dept_name: 'Engineering', employee: 'Bob', salary: 80000 },
-        { dept_name: 'Engineering', employee: 'Alice', salary: 75000 },
-        { dept_name: 'Sales', employee: 'Diana', salary: 65000 },
-        { dept_name: 'Sales', employee: 'Charlie', salary: 60000 },
-      ])
-    end
-  end
-
   describe 'MERGE feature' do
-    let(:target_table) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
-    let(:source_table) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
+    before(:all) do
+      @target_table = "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym
+      @source_table = "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym
 
-    before(:each) do
-      db.create_table(target_table, :temp => true) do
+      @db.create_table(@target_table, :temp => true) do
         String :str
         String :str2
         String :str3
       end
 
-      db.create_table(source_table, :temp => true) do
+      @db.create_table(@source_table, :temp => true) do
         String :from
         String :to
         String :whomst
       end
-
-      db[target_table].insert({ str: 'foo', str2: 'foo', str3: 'phoo' })
-      db[target_table].insert({ str: 'baz', str2: 'foo', str3: 'buzz' })
-      db[source_table].insert({ from: 'foo', to: 'bar', whomst: 'me' })
     end
 
-    after(:each) do
-      db.drop_table(target_table)
-      db.drop_table(source_table)
+    after(:all) do
+      @db.drop_table(@target_table) if @target_table
+      @db.drop_table(@source_table) if @source_table
     end
+
+    before(:each) do
+      # Clear and repopulate data for each test since MERGE modifies data
+      db[@target_table].delete
+      db[@source_table].delete
+      db[@target_table].insert({ str: 'foo', str2: 'foo', str3: 'phoo' })
+      db[@target_table].insert({ str: 'baz', str2: 'foo', str3: 'buzz' })
+      db[@source_table].insert({ from: 'foo', to: 'bar', whomst: 'me' })
+    end
+
+    let(:target_table) { @target_table }
+    let(:source_table) { @source_table }
 
     it 'can use MERGE' do
       db[target_table].merge_using(source_table, str: :from).merge_update(str2: :to).merge
@@ -348,25 +240,26 @@ describe Sequel::Snowflake::Dataset do
   end
 
   describe '#explain' do
-    # Create a test table with a reasonably-random suffix
-    let(:test_table) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
+    before(:all) do
+      @test_table = "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym
 
-    before(:each) do
-      db.create_table(test_table, :temp => true) do
+      @db.create_table(@test_table, :temp => true) do
         Numeric :id
         String :name
         String :email
         String :title
       end
 
-      db[test_table].insert(
+      @db[@test_table].insert(
         { id: 1, name: 'John Null', email: 'j.null@example.com', title: 'Software Tester' }
       )
     end
 
-    after(:each) do
-      db.drop_table(test_table)
+    after(:all) do
+      @db.drop_table(@test_table) if @test_table
     end
+
+    let(:test_table) { @test_table }
 
     it "should have explain output" do
       query = db.fetch("SELECT * FROM #{test_table} WHERE ID=1;")

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -254,7 +254,53 @@ describe Sequel::Snowflake::Dataset do
   end
 
   describe 'LATERAL JOIN feature' do
+    let(:employees) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
+    let(:departments) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
 
+    before(:each) do
+      db.create_table(departments, :temp => true) do
+        Integer :dept_id
+        String :dept_name
+        Integer :budget
+      end
+
+      db.create_table(employees, :temp => true) do
+        Integer :emp_id
+        String :emp_name
+        Integer :dept_id
+        Integer :salary
+      end
+
+      db[departments].insert({ dept_id: 1, dept_name: 'Engineering', budget: 100000 })
+      db[departments].insert({ dept_id: 2, dept_name: 'Sales', budget: 80000 })
+      db[employees].insert({ emp_id: 1, emp_name: 'Alice', dept_id: 1, salary: 75000 })
+      db[employees].insert({ emp_id: 2, emp_name: 'Bob', dept_id: 1, salary: 80000 })
+      db[employees].insert({ emp_id: 3, emp_name: 'Charlie', dept_id: 2, salary: 60000 })
+      db[employees].insert({ emp_id: 4, emp_name: 'Diana', dept_id: 2, salary: 65000 })
+    end
+
+    after(:each) do
+      db.drop_table(employees)
+      db.drop_table(departments)
+    end
+
+    it 'can use LATERAL JOIN' do
+      query = <<-SQL
+        SELECT d.dept_name, e.emp_name AS employee, e.salary
+        FROM #{departments} AS d,
+        LATERAL (SELECT emp_name, salary FROM #{employees} AS e WHERE e.dept_id = d.dept_id) AS e
+        ORDER BY d.dept_name, e.salary DESC
+        SQL
+
+      res = db.fetch(query).all
+
+      expect(res).to match_array([
+        { dept_name: 'Engineering', employee: 'Bob', salary: 80000 },
+        { dept_name: 'Engineering', employee: 'Alice', salary: 75000 },
+        { dept_name: 'Sales', employee: 'Diana', salary: 65000 },
+        { dept_name: 'Sales', employee: 'Charlie', salary: 60000 },
+      ])
+    end
   end
 
   describe 'MERGE feature' do

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -70,6 +70,85 @@ describe Sequel::Snowflake::Dataset do
     end
   end
 
+  describe 'GROUP CUBE feature' do
+    let(:products) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
+    let(:sales) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
+
+    before(:each) do
+      db.create_table(products, :temp => true) do
+        Integer :product_id
+        Float :wholesale_price
+      end
+
+      db.create_table(sales, :temp => true) do
+        Integer :product_id
+        Float :retail_price
+        Integer :quantity
+        String :city
+        String :state
+      end
+
+      db[products].insert({ product_id: 1, wholesale_price: 1.00 })
+      db[products].insert({ product_id: 2, wholesale_price: 2.00 })
+      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 1, city: 'SF', state: 'CA' })
+      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 2, city: 'SJ', state: 'CA' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 4, city: 'SF', state: 'CA' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 8, city: 'SJ', state: 'CA' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 16, city: 'Miami', state: 'FL' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 32, city: 'Orlando', state: 'FL' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 64, city: 'SJ', state: 'CA' })
+    end
+
+    after(:each) do
+      db.drop_table(products)
+      db.drop_table(sales)
+    end
+
+    it 'can use GROUP CUBE' do
+      query = <<-SQL
+        SELECT state, city, SUM((s.retail_price - p.wholesale_price) * s.quantity) AS profit
+        FROM #{products} AS p, #{sales} AS s
+        WHERE p.product_id = s.product_id
+        SQL
+
+      res = db.
+        fetch(query).
+        group_cube(:state, :city).
+        order(Sequel.asc(:state, nulls: :last)).
+        order_append(:city).
+        select_all.
+        all
+
+      expect(res).to match_array([
+        { state: 'CA', city: 'SF', profit: 13 },
+        { state: 'CA', city: 'SJ', profit: 26 },
+        { state: 'CA', city: nil, profit: 39 },
+        { state: 'FL', city: 'Miami', profit: 48 },
+        { state: 'FL', city: 'Orlando', profit: 96 },
+        { state: 'FL', city: nil, profit: 144 },
+        { state: 'PR', city: 'SJ', profit: 192 },
+        { state: 'PR', city: nil, profit: 192 },
+        { state: nil, city: 'Miami', profit: 48 },
+        { state: nil, city: 'Orlando', profit: 96 },
+        { state: nil, city: 'SF', profit: 13 },
+        { state: nil, city: 'SJ', profit: 218 },
+        { state: nil, city: nil, profit: 375 },
+      ])
+    end
+  end
+
+  describe 'GROUP ROLLUP feature' do
+
+  end
+
+  describe 'GROUPING SETS feature' do
+
+  end
+
+  describe 'LATERAL JOIN feature' do
+
+  end
+
   describe 'MERGE feature' do
     let(:target_table) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
     let(:source_table) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -135,7 +135,63 @@ describe Sequel::Snowflake::Dataset do
   end
 
   describe 'GROUP ROLLUP feature' do
+    let(:products) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
+    let(:sales) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
 
+    before(:each) do
+      db.create_table(products, :temp => true) do
+        Integer :product_id
+        Float :wholesale_price
+      end
+
+      db.create_table(sales, :temp => true) do
+        Integer :product_id
+        Float :retail_price
+        Integer :quantity
+        String :city
+        String :state
+      end
+
+      db[products].insert({ product_id: 1, wholesale_price: 1.00 })
+      db[products].insert({ product_id: 2, wholesale_price: 2.00 })
+      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 1, city: 'SF', state: 'CA' })
+      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 2, city: 'SJ', state: 'CA' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 4, city: 'SF', state: 'CA' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 8, city: 'SJ', state: 'CA' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 16, city: 'Miami', state: 'FL' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 32, city: 'Orlando', state: 'FL' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 64, city: 'SJ', state: 'CA' })
+    end
+
+    after(:each) do
+      db.drop_table(products)
+      db.drop_table(sales)
+    end
+
+    it 'can use GROUP ROLLUP' do
+      query = <<-SQL
+        SELECT s.state, s.city, SUM((s.retail_price - p.wholesale_price) * s.quantity) AS profit
+        FROM #{products} AS p, #{sales} AS s
+        WHERE p.product_id = s.product_id
+        GROUP BY ROLLUP (s.state, s.city)
+        SQL
+
+      res = db.
+        fetch(query).
+        order(Sequel.asc(:state, nulls: :last)).
+        order_append(:city).
+        all
+
+      expect(res).to match_array([
+        { state: 'CA', city: 'SF', profit: 13 },
+        { state: 'CA', city: 'SJ', profit: 218 },
+        { state: 'CA', city: nil, profit: 231 },
+        { state: 'FL', city: 'Miami', profit: 48 },
+        { state: 'FL', city: 'Orlando', profit: 96 },
+        { state: 'FL', city: nil, profit: 144 },
+        { state: nil, city: nil, profit: 375 },
+      ])
+    end
   end
 
   describe 'GROUPING SETS feature' do

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -71,7 +71,67 @@ describe Sequel::Snowflake::Dataset do
   end
 
   describe 'GROUP CUBE feature' do
+    let(:products) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
+    let(:sales) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
 
+    before(:each) do
+      db.create_table(products, :temp => true) do
+        Integer :product_id
+        Float :wholesale_price
+      end
+
+      db.create_table(sales, :temp => true) do
+        Integer :product_id
+        Float :retail_price
+        Integer :quantity
+        String :city
+        String :state
+      end
+
+      db[products].insert({ product_id: 1, wholesale_price: 1.00 })
+      db[products].insert({ product_id: 2, wholesale_price: 2.00 })
+      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 1, city: 'SF', state: 'CA' })
+      db[sales].insert({ product_id: 1, retail_price: 2.00, quantity: 2, city: 'SJ', state: 'CA' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 4, city: 'SF', state: 'CA' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 8, city: 'SJ', state: 'CA' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 16, city: 'Miami', state: 'FL' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 32, city: 'Orlando', state: 'FL' })
+      db[sales].insert({ product_id: 2, retail_price: 5.00, quantity: 64, city: 'SJ', state: 'CA' })
+    end
+
+    after(:each) do
+      db.drop_table(products)
+      db.drop_table(sales)
+    end
+
+    it 'can use GROUP CUBE' do
+      query = <<-SQL
+        SELECT s.state, s.city, SUM((s.retail_price - p.wholesale_price) * s.quantity) AS profit
+        FROM #{products} AS p, #{sales} AS s
+        WHERE p.product_id = s.product_id
+        GROUP BY CUBE (s.state, s.city)
+        SQL
+
+      res = db.
+        fetch(query).
+        order(Sequel.asc(:state, nulls: :last)).
+        order_append(:city).
+        all
+
+      expect(res).to match_array([
+        { state: 'CA', city: 'SF', profit: 13 },
+        { state: 'CA', city: 'SJ', profit: 218 },
+        { state: 'CA', city: nil, profit: 231 },
+        { state: 'FL', city: 'Miami', profit: 48 },
+        { state: 'FL', city: 'Orlando', profit: 96 },
+        { state: 'FL', city: nil, profit: 144 },
+        { state: nil, city: 'Miami', profit: 48 },
+        { state: nil, city: 'Orlando', profit: 96 },
+        { state: nil, city: 'SF', profit: 13 },
+        { state: nil, city: 'SJ', profit: 218 },
+        { state: nil, city: nil, profit: 375 },
+      ])
+    end
   end
 
   describe 'GROUP ROLLUP feature' do

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -113,7 +113,8 @@ describe Sequel::Snowflake::Dataset do
 
       res = db.
         fetch(query).
-        group_cube(:state, :city).
+        group(:state, :city).
+        group_cube.
         order(Sequel.asc(:state, nulls: :last)).
         order_append(:city).
         select_all.

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -71,6 +71,14 @@ describe Sequel::Snowflake::Dataset do
   end
 
   describe 'GROUP CUBE feature' do
+
+  end
+
+  describe 'GROUP ROLLUP feature' do
+
+  end
+
+  describe 'GROUPING SETS feature' do
     let(:products) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
     let(:sales) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
 
@@ -104,46 +112,29 @@ describe Sequel::Snowflake::Dataset do
       db.drop_table(sales)
     end
 
-    it 'can use GROUP CUBE' do
+    it 'can use GROUPING SETS' do
       query = <<-SQL
-        SELECT state, city, SUM((s.retail_price - p.wholesale_price) * s.quantity) AS profit
+        SELECT s.state, s.city, SUM((s.retail_price - p.wholesale_price) * s.quantity) AS profit
         FROM #{products} AS p, #{sales} AS s
         WHERE p.product_id = s.product_id
+        GROUP BY GROUPING SETS ((s.state), (s.city))
         SQL
 
       res = db.
         fetch(query).
-        group(:state, :city).
-        group_cube.
         order(Sequel.asc(:state, nulls: :last)).
         order_append(:city).
-        select_all.
         all
 
       expect(res).to match_array([
-        { state: 'CA', city: 'SF', profit: 13 },
-        { state: 'CA', city: 'SJ', profit: 26 },
-        { state: 'CA', city: nil, profit: 39 },
-        { state: 'FL', city: 'Miami', profit: 48 },
-        { state: 'FL', city: 'Orlando', profit: 96 },
+        { state: 'CA', city: nil, profit: 231 },
         { state: 'FL', city: nil, profit: 144 },
-        { state: 'PR', city: 'SJ', profit: 192 },
-        { state: 'PR', city: nil, profit: 192 },
         { state: nil, city: 'Miami', profit: 48 },
         { state: nil, city: 'Orlando', profit: 96 },
         { state: nil, city: 'SF', profit: 13 },
         { state: nil, city: 'SJ', profit: 218 },
-        { state: nil, city: nil, profit: 375 },
       ])
     end
-  end
-
-  describe 'GROUP ROLLUP feature' do
-
-  end
-
-  describe 'GROUPING SETS feature' do
-
   end
 
   describe 'LATERAL JOIN feature' do

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -105,17 +105,17 @@ describe Sequel::Snowflake::Dataset do
     end
 
     it 'can use GROUP CUBE' do
-      query = <<-SQL
-        SELECT s.state, s.city, SUM((s.retail_price - p.wholesale_price) * s.quantity) AS profit
-        FROM #{products} AS p, #{sales} AS s
-        WHERE p.product_id = s.product_id
-        GROUP BY CUBE (s.state, s.city)
-        SQL
-
-      res = db.
-        fetch(query).
-        order(Sequel.asc(:state, nulls: :last)).
-        order_append(:city).
+      res = db.from(Sequel[products].as(:p)).
+        join(Sequel[sales].as(:s), Sequel[:p][:product_id] => Sequel[:s][:product_id]).
+        select(
+          Sequel[:s][:state],
+          Sequel[:s][:city],
+          Sequel.function(:sum, Sequel.*(Sequel.-(Sequel[:s][:retail_price], Sequel[:p][:wholesale_price]), Sequel[:s][:quantity])).as(:profit)
+        ).
+        group(Sequel[:s][:state], Sequel[:s][:city]).
+        group_cube.
+        order(Sequel.asc(Sequel[:s][:state], nulls: :last)).
+        order_append(Sequel[:s][:city]).
         all
 
       expect(res).to match_array([
@@ -169,17 +169,17 @@ describe Sequel::Snowflake::Dataset do
     end
 
     it 'can use GROUP ROLLUP' do
-      query = <<-SQL
-        SELECT s.state, s.city, SUM((s.retail_price - p.wholesale_price) * s.quantity) AS profit
-        FROM #{products} AS p, #{sales} AS s
-        WHERE p.product_id = s.product_id
-        GROUP BY ROLLUP (s.state, s.city)
-        SQL
-
-      res = db.
-        fetch(query).
-        order(Sequel.asc(:state, nulls: :last)).
-        order_append(:city).
+      res = db.from(Sequel[products].as(:p)).
+        join(Sequel[sales].as(:s), Sequel[:p][:product_id] => Sequel[:s][:product_id]).
+        select(
+          Sequel[:s][:state],
+          Sequel[:s][:city],
+          Sequel.function(:sum, Sequel.*(Sequel.-(Sequel[:s][:retail_price], Sequel[:p][:wholesale_price]), Sequel[:s][:quantity])).as(:profit)
+        ).
+        group(Sequel[:s][:state], Sequel[:s][:city]).
+        group_rollup.
+        order(Sequel.asc(Sequel[:s][:state], nulls: :last)).
+        order_append(Sequel[:s][:city]).
         all
 
       expect(res).to match_array([
@@ -229,17 +229,17 @@ describe Sequel::Snowflake::Dataset do
     end
 
     it 'can use GROUPING SETS' do
-      query = <<-SQL
-        SELECT s.state, s.city, SUM((s.retail_price - p.wholesale_price) * s.quantity) AS profit
-        FROM #{products} AS p, #{sales} AS s
-        WHERE p.product_id = s.product_id
-        GROUP BY GROUPING SETS ((s.state), (s.city))
-        SQL
-
-      res = db.
-        fetch(query).
-        order(Sequel.asc(:state, nulls: :last)).
-        order_append(:city).
+      res = db.from(Sequel[products].as(:p)).
+        join(Sequel[sales].as(:s), Sequel[:p][:product_id] => Sequel[:s][:product_id]).
+        select(
+          Sequel[:s][:state],
+          Sequel[:s][:city],
+          Sequel.function(:sum, Sequel.*(Sequel.-(Sequel[:s][:retail_price], Sequel[:p][:wholesale_price]), Sequel[:s][:quantity])).as(:profit)
+        ).
+        group([Sequel[:s][:state]], [Sequel[:s][:city]]).
+        grouping_sets.
+        order(Sequel.asc(Sequel[:s][:state], nulls: :last)).
+        order_append(Sequel[:s][:city]).
         all
 
       expect(res).to match_array([
@@ -285,14 +285,21 @@ describe Sequel::Snowflake::Dataset do
     end
 
     it 'can use LATERAL JOIN' do
-      query = <<-SQL
-        SELECT d.dept_name, e.emp_name AS employee, e.salary
-        FROM #{departments} AS d,
-        LATERAL (SELECT emp_name, salary FROM #{employees} AS e WHERE e.dept_id = d.dept_id) AS e
-        ORDER BY d.dept_name, e.salary DESC
-        SQL
-
-      res = db.fetch(query).all
+      res = db.from(
+        Sequel[departments].as(:d),
+        db[employees].
+          where(Sequel[:d][:dept_id] => :dept_id).
+          select(:emp_name, :salary).
+          lateral.
+          as(:e)
+      ).
+        select(
+          Sequel[:d][:dept_name],
+          Sequel[:e][:emp_name].as(:employee),
+          Sequel[:e][:salary]
+        ).
+        order(Sequel[:d][:dept_name], Sequel.desc(Sequel[:e][:salary])).
+        all
 
       expect(res).to match_array([
         { dept_name: 'Engineering', employee: 'Bob', salary: 80000 },


### PR DESCRIPTION
This might be our last update for this gem, as maintaining this requires access to Snowflake so we can write and run tests.

----

This adds support for the various GROUP BY options (CUBE, ROLLUP, SETS), so users may use the Sequel DSL to perform queries requiring those functions.

This also bumps us up to testing against Ruby 3.4 (just in time for Ruby 3.5 to probably come out next month)!