### PR TITLE
Update README; Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,8 @@
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
 name: Ruby
+permissions:
+  contents: read
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # sequel-snowflake
 
+> [!WARNING]
+> This gem is no longer maintained, as we no longer use Snowflake and don't have any way
+to run tests moving forward. New maintainers or a fork is recommended.
+
 An adapter to connect to Snowflake databases using [Sequel](http://sequel.jeremyevans.net/).
 This provides proper types for returned values, as opposed to the ODBC adapter.
 


### PR DESCRIPTION
This pull fixes a security suggestion for our workflow, and also updates the README now that we no longer use Snowflake. Without a paid Snowflake account, we won't be able to run tests, so maintaining this gem is not possible.

---

Potential fix for [https://github.com/vendasta/sequel-snowflake/security/code-scanning/1](https://github.com/vendasta/sequel-snowflake/security/code-scanning/1)

To fix the workflow, explicitly limit the GITHUB_TOKEN permissions by adding a `permissions` block. As none of the steps require writing to the repo (e.g., creating releases, deploying, or opening pull requests), the correct minimal permissions are `contents: read`. This `permissions` block can be set at the workflow root (recommended, so it applies to all jobs by default), or within the specific `jobs.test` job. The best way is to add it immediately after the `name:` declaration and above the `on:` block.

**What to change:**
- Edit `.github/workflows/ruby.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name: Ruby` line (line 8 or 9).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
