### PR TITLE
Add service-level.yaml — Honey Badger ownership

### DIFF
--- a/service-level.yaml
+++ b/service-level.yaml
@@ -1,0 +1,6 @@
+services:
+  - name: sequel-snowflake
+    owner: honey-badger
+    language: ruby
+    nonServiceType: library
+    description: "Sequel adapter gem for connecting to Snowflake databases via ODBC (no longer maintained)"


### PR DESCRIPTION
Declares ownership and classification for this repository in its `service-level.yaml`, so it appears in the internal service catalog (https://employees.vendasta-internal.com/services) under the **Honey Badger** team instead of the "missing service-level.yaml" list.

This repo has no deployed service (no `APP_SHAPE_MAP`/deploy config), so it is classified with `nonServiceType: library`.

Part of CTO-45: adding service-level.yaml to the Yesware repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)